### PR TITLE
populate agent_id in PostgresStore#serialize_trace (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.13] - 2026-03-26
+
+### Fixed
+- `PostgresStore#serialize_trace` omitted `agent_id` column, causing `PG::NotNullViolation` on every insert against PostgreSQL (migration 022 declares `agent_id null: false`). Constructor now accepts `agent_id:` with fallback to `Legion::Settings.dig(:agent, :id)` or `'default'`
+- `Trace.create_store` factory now resolves and passes `agent_id` to PostgresStore
+- Spec schema for PostgresStore now includes `agent_id` column matching production migration
+
 ## [0.1.12] - 2026-03-26
 
 ### Fixed

--- a/lib/legion/extensions/agentic/memory/trace.rb
+++ b/lib/legion/extensions/agentic/memory/trace.rb
@@ -34,7 +34,7 @@ module Legion
             def create_store
               if postgres_available?
                 Legion::Logging.debug '[memory] Using shared PostgresStore (write-through)'
-                Helpers::PostgresStore.new(tenant_id: resolve_tenant_id)
+                Helpers::PostgresStore.new(tenant_id: resolve_tenant_id, agent_id: resolve_agent_id)
               elsif defined?(Legion::Cache) && Legion::Cache.respond_to?(:connected?) && Legion::Cache.connected?
                 Legion::Logging.debug '[memory] Using shared CacheStore (memcached)'
                 Helpers::CacheStore.new
@@ -59,6 +59,12 @@ module Legion
               Legion::Settings[:data]&.dig(:tenant_id)
             rescue StandardError
               nil
+            end
+
+            def resolve_agent_id
+              Legion::Settings.dig(:agent, :id) || 'default'
+            rescue StandardError
+              'default'
             end
           end
         end

--- a/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
@@ -15,8 +15,9 @@ module Legion
               TRACES_TABLE = :memory_traces
               ASSOCIATIONS_TABLE = :memory_associations
 
-              def initialize(tenant_id: nil)
+              def initialize(tenant_id: nil, agent_id: nil)
                 @tenant_id = tenant_id
+                @agent_id  = agent_id || resolve_agent_id
               end
 
               # Store (upsert) a trace by trace_id.
@@ -262,6 +263,12 @@ module Legion
                 Legion::Data.connection
               end
 
+              def resolve_agent_id
+                Legion::Settings.dig(:agent, :id) || 'default'
+              rescue StandardError
+                'default'
+              end
+
               # Dataset for memory_traces scoped by tenant_id (if set).
               def traces_ds
                 ds = db[TRACES_TABLE]
@@ -277,6 +284,7 @@ module Legion
 
                 {
                   trace_id:                trace[:trace_id],
+                  agent_id:                @agent_id,
                   tenant_id:               @tenant_id,
                   trace_type:              trace[:trace_type].to_s,
                   content:                 payload.is_a?(Hash) ? Legion::JSON.dump(payload) : payload.to_s,

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.12'
+        VERSION = '0.1.13'
       end
     end
   end

--- a/spec/legion/extensions/agentic/memory/trace/helpers/postgres_store_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/postgres_store_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::PostgresStor
     d.create_table(:memory_traces) do
       primary_key :id
       String  :trace_id, size: 36, null: false, unique: true
+      String  :agent_id, size: 64, null: false, default: 'test-agent'
       String  :tenant_id, size: 64
       String  :trace_type, null: false
       String  :content, text: true, null: false
@@ -124,6 +125,23 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::PostgresStor
 
       expect(ds).to have_received(:insert_conflict)
         .with(hash_including(target: :trace_id))
+    end
+  end
+
+  # --- store agent_id population ---
+
+  describe '#store agent_id population' do
+    it 'writes agent_id to the database row' do
+      store.store(semantic_trace)
+      row = db[:memory_traces].where(trace_id: semantic_trace[:trace_id]).first
+      expect(row[:agent_id]).not_to be_nil
+    end
+
+    it 'uses the resolved agent_id from settings' do
+      custom_store = described_class.new(tenant_id: tenant_id, agent_id: 'my-agent')
+      custom_store.store(semantic_trace)
+      row = db[:memory_traces].where(trace_id: semantic_trace[:trace_id]).first
+      expect(row[:agent_id]).to eq('my-agent')
     end
   end
 


### PR DESCRIPTION
## Summary
- `PostgresStore#serialize_trace` omitted `agent_id`, causing `PG::NotNullViolation` on every insert against PostgreSQL
- Constructor now accepts `agent_id:` with fallback to `Legion::Settings.dig(:agent, :id)` or `'default'`
- `Trace.create_store` factory resolves and passes `agent_id` to PostgresStore

Closes #7

## Changes
- `lib/.../postgres_store.rb` — accept `agent_id:` in constructor, add `resolve_agent_id` private method, include `agent_id` in `serialize_trace` hash
- `lib/.../trace.rb` — add `resolve_agent_id` helper, pass to PostgresStore in `create_store`
- `spec/.../postgres_store_spec.rb` — add `agent_id` column to in-memory test schema, add 2 specs for agent_id population
- `version.rb` — bump to 0.1.13
- `CHANGELOG.md` — add 0.1.13 entry

## Test Coverage
- 1936 specs, 0 failures
- `bundle exec rubocop` — 291 files, 0 offenses
- 2 new specs: verifies `agent_id` is written to DB, verifies explicit `agent_id:` is used when provided