### PR TITLE
[codex] Reduce local memory persistence churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Gemfile.lock
-Gemfile.lock
 .rspec_status
 *.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.30] - 2026-04-27
+### Fixed
+- Local trace persistence now writes only changed trace rows instead of upserting every trace in the partition for a one-trace update.
+- Local association persistence now stores `partition_id` and restores associations by partition, avoiding a startup query with one giant trace-id `IN (...)` list.
+
 ## [0.1.29] - 2026-04-22
 ### Fixed
 - `parse_db_content` no longer attempts JSON parse on plain-text content — checks for `{`/`[` prefix before parsing, returns raw string for non-JSON content without logging errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.31] - 2026-04-27
+### Added
+- Add a heuristic pre-compaction memory save path and synchronous pre-compaction event listeners for `chat.pre_compact`, `context.pre_compact`, and `conversation.pre_compact`.
+
+### Fixed
+- Require `legion/logging` and `legion/cache/helper` before `CacheStore` includes helper APIs, preventing `log` or cache helper methods from being skipped when the file is loaded directly.
+- Pass `CacheStore` TTL values through `cache_set` as keywords so flushes work with the shared cache helper API.
+
 ## [0.1.30] - 2026-04-27
 ### Fixed
 - Local trace persistence now writes only changed trace rows instead of upserting every trace in the partition for a one-trace update.

--- a/lib/legion/extensions/agentic/memory.rb
+++ b/lib/legion/extensions/agentic/memory.rb
@@ -12,6 +12,7 @@ require_relative 'memory/echo'
 require_relative 'memory/echo_chamber'
 require_relative 'memory/immune_memory'
 require_relative 'memory/reserve'
+require_relative 'memory/consolidation'
 require_relative 'memory/trace'
 require_relative 'memory/episodic'
 require_relative 'memory/semantic'
@@ -42,6 +43,12 @@ module Legion
         def self.transport_required?
           false
         end
+
+        def self.handle_pre_compact_event(event)
+          agent_id = event[:agent_id] || event[:agent]
+          session = event[:session] || event[:transcript] || event[:messages]
+          Consolidation::PreCompact.before_compact(session: session, agent_id: agent_id)
+        end
       end
     end
   end
@@ -68,6 +75,13 @@ if defined?(Legion::Events)
 
       agent_id = (settings_loaded ? Legion::Settings.dig(:agent, :id) : nil) || 'default'
       Legion::Extensions::Agentic::Memory::Trace::Helpers::Snapshot.restore_snapshot(agent_id: agent_id)
+    end
+  end
+
+  pre_compact_enabled = settings_loaded ? Legion::Settings.dig(:memory, :pre_compact, :enabled) != false : true
+  if pre_compact_enabled
+    %w[chat.pre_compact context.pre_compact conversation.pre_compact].each do |event_name|
+      Legion::Events.on(event_name) { |event| Legion::Extensions::Agentic::Memory.handle_pre_compact_event(event) }
     end
   end
 end

--- a/lib/legion/extensions/agentic/memory/consolidation.rb
+++ b/lib/legion/extensions/agentic/memory/consolidation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'consolidation/helpers/extractor'
+require_relative 'consolidation/pre_compact'
+
+module Legion
+  module Extensions
+    module Agentic
+      module Memory
+        module Consolidation
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/agentic/memory/consolidation/helpers/extractor.rb
+++ b/lib/legion/extensions/agentic/memory/consolidation/helpers/extractor.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Agentic
+      module Memory
+        module Consolidation
+          module Helpers
+            module Extractor
+              CATEGORY_PATTERNS = {
+                decisions:   /\b(decided|decision|went with|choose|chosen|locked in|settled on)\b/i,
+                preferences: /\b(always|never|prefer|preference|use .* by default|do not|don't)\b/i,
+                milestones:  /\b(worked|fixed|green|merged|shipped|completed|breakthrough|finally)\b/i,
+                problems:    /\b(bug|failed|failing|failure|broken|error|crash|root cause|regression|blocked)\b/i,
+                discoveries: /\b(found|learned|discovered|turns out|confirmed|observed)\b/i
+              }.freeze
+
+              module_function
+
+              def extract(transcript)
+                lines = transcript_lines(transcript)
+                CATEGORY_PATTERNS.each_with_object({}) do |(category, pattern), summary|
+                  summary[category] = lines.grep(pattern).uniq
+                end
+              end
+
+              def transcript_lines(transcript)
+                text = transcript_text(transcript)
+                text.split(/[\r\n]+|(?<=[.!?])\s+/)
+                    .map { |line| line.strip.gsub(/\s+/, ' ') }
+                    .reject(&:empty?)
+              end
+
+              def transcript_text(transcript)
+                case transcript
+                when String
+                  transcript
+                when Array
+                  transcript.map { |entry| entry_text(entry) }.join("\n")
+                else
+                  session_messages(transcript).map { |entry| entry_text(entry) }.join("\n")
+                end
+              end
+
+              def session_messages(session)
+                return [] unless session
+                return session.transcript if session.respond_to?(:transcript)
+                return session.messages if session.respond_to?(:messages)
+                return session.chat.messages if session.respond_to?(:chat) && session.chat.respond_to?(:messages)
+
+                []
+              end
+
+              def entry_text(entry)
+                return entry if entry.is_a?(String)
+
+                if entry.respond_to?(:to_h)
+                  hash = entry.to_h
+                  return hash[:content] || hash['content'] || hash[:text] || hash['text'] || hash.to_s
+                end
+
+                entry.respond_to?(:content) ? entry.content.to_s : entry.to_s
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/agentic/memory/consolidation/pre_compact.rb
+++ b/lib/legion/extensions/agentic/memory/consolidation/pre_compact.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'time'
+require 'legion/logging'
+require_relative '../trace'
+require_relative 'helpers/extractor'
+
+module Legion
+  module Extensions
+    module Agentic
+      module Memory
+        module Consolidation
+          module PreCompact
+            class << self
+              include Legion::Logging::Helper if defined?(Legion::Logging::Helper)
+
+              def before_compact(session:, agent_id: nil, store: nil, apollo: nil)
+                summary = Helpers::Extractor.extract(session)
+                saved = persist_summary(summary, session: session, agent_id: agent_id, store: store)
+                promote_summary(summary, agent_id: agent_id, apollo: apollo)
+
+                { success: true, agent_id: resolved_agent_id(agent_id), saved: saved, summary: summary }
+              rescue StandardError => e
+                log.warn("[memory] pre_compact save failed: #{e.message}")
+                { success: false, reason: :error, message: e.message }
+              end
+
+              private
+
+              def persist_summary(summary, session:, agent_id:, store:)
+                memory_store = store || Trace.shared_store
+                return 0 unless memory_store.respond_to?(:store)
+
+                saved = 0
+                summary.each do |category, entries|
+                  entries.each do |entry|
+                    memory_store.store(trace_for(category, entry, session: session, agent_id: agent_id))
+                    saved += 1
+                  end
+                end
+                memory_store.flush if memory_store.respond_to?(:flush)
+                saved
+              end
+
+              def promote_summary(summary, agent_id:, apollo:)
+                writer = apollo || (Legion::Apollo if defined?(Legion::Apollo))
+                return unless writer.respond_to?(:ingest)
+
+                summary.each do |category, entries|
+                  entries.each do |entry|
+                    writer.ingest(
+                      content:        entry,
+                      tags:           ['pre_compact', category.to_s, "agent:#{resolved_agent_id(agent_id)}"],
+                      source_channel: 'memory_pre_compact'
+                    )
+                  end
+                end
+              rescue StandardError => e
+                log.warn("[memory] pre_compact Apollo promotion failed: #{e.message}")
+              end
+
+              def trace_for(category, entry, session:, agent_id:)
+                Trace::Helpers::Trace.new_trace(
+                  type:            :semantic,
+                  content_payload: {
+                    category:   category,
+                    text:       entry,
+                    session_id: session_id(session),
+                    saved_at:   Time.now.utc.iso8601
+                  },
+                  domain_tags:     ['pre_compact', category.to_s],
+                  source_agent_id: resolved_agent_id(agent_id),
+                  partition_id:    resolved_agent_id(agent_id)
+                )
+              end
+
+              def session_id(session)
+                return session.id if session.respond_to?(:id)
+                return session[:id] if session.is_a?(Hash) && session.key?(:id)
+                return session['id'] if session.is_a?(Hash)
+
+                SecureRandom.uuid
+              end
+
+              def resolved_agent_id(agent_id)
+                agent_id || (Legion::Settings.dig(:agent, :id) if defined?(Legion::Settings)) || 'default'
+              rescue StandardError => e
+                log.warn("[memory] pre_compact agent id resolution failed: #{e.message}")
+                'default'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/agentic/memory/trace/helpers/cache_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/cache_store.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'legion/logging'
+require 'legion/cache/helper'
+
 module Legion
   module Extensions
     module Agentic
@@ -12,6 +15,7 @@ module Legion
             # Keeps a local in-memory copy for fast reads; syncs to cache on flush.
             class CacheStore
               include Legion::Logging::Helper if defined?(Legion::Logging::Helper)
+              include Legion::Cache::Helper if defined?(Legion::Cache::Helper)
 
               TRACE_PREFIX = 'legion:memory:trace:'
               INDEX_KEY    = 'legion:memory:trace_index'
@@ -194,7 +198,7 @@ module Legion
                 @dirty_ids.each_slice(FLUSH_BATCH) do |batch|
                   batch.each do |id|
                     trace = @traces[id]
-                    cache_set(trace_key(id), trace, TTL) if trace
+                    cache_set(trace_key(id), trace, ttl: TTL) if trace
                   end
                 end
               end
@@ -208,7 +212,7 @@ module Legion
               def flush_associations
                 return unless @assoc_dirty
 
-                cache_set(ASSOC_KEY, strip_default_procs(@associations), TTL)
+                cache_set(ASSOC_KEY, strip_default_procs(@associations), ttl: TTL)
                 @assoc_dirty = false
               rescue StandardError => e
                 log.warn("[memory] CacheStore flush_associations failed (#{@associations.size} entries): #{e.message}")
@@ -217,7 +221,7 @@ module Legion
               def flush_index
                 return if @dirty_ids.empty? && @deleted_ids.empty?
 
-                cache_set(INDEX_KEY, @traces.keys, TTL)
+                cache_set(INDEX_KEY, @traces.keys, ttl: TTL)
               rescue StandardError => e
                 log.warn("[memory] CacheStore flush_index failed (#{@traces.size} traces): #{e.message}")
               end

--- a/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
@@ -13,6 +13,8 @@ module Legion
             class Store
               include Legion::Logging::Helper if defined?(Legion::Logging::Helper)
 
+              ASSOCIATION_LOAD_BATCH_SIZE = 500
+
               attr_reader :traces, :associations
 
               def initialize(partition_id: nil)
@@ -166,49 +168,61 @@ module Legion
                 snapshots = snapshot_dirty_state
                 return unless snapshots
 
-                traces_snapshot, associations_snapshot, trace_rows_snapshot, traces_dirty, associations_dirty = snapshots
+                traces_snapshot, associations_snapshot, trace_rows_snapshot, trace_changes, associations_dirty = snapshots
                 db.transaction do
                   scoped_trace_ids = db[:memory_traces].where(partition_id: @partition_id).select_map(:trace_id)
                   memory_trace_ids = traces_snapshot.keys
-                  stale_ids = persist_dirty_traces(db, trace_rows_snapshot, scoped_trace_ids, memory_trace_ids, traces_dirty)
+                  stale_ids = scoped_trace_ids - memory_trace_ids
+                  persist_dirty_traces(db, trace_rows_snapshot, trace_changes, stale_ids)
                   persist_dirty_associations(db, associations_snapshot, scoped_trace_ids, memory_trace_ids, stale_ids, associations_dirty)
                 end
                 clear_dirty_flags(trace_rows_snapshot)
               end
 
               def snapshot_dirty_state
-                traces_snapshot, associations_snapshot, trace_rows_snapshot, traces_dirty, associations_dirty = @mutex.synchronize do
+                traces_snapshot, associations_snapshot, trace_rows_snapshot, trace_changes, associations_dirty = @mutex.synchronize do
                   ts = @traces.transform_values(&:dup)
                   as = @associations.each_with_object({}) { |(tid, targets), memo| memo[tid] = targets.dup }
                   trs = ts.transform_values { |trace| serialize_trace_for_db(trace) }
-                  [ts, as, trs, @traces_dirty || trs != @persisted_trace_rows, @associations_dirty]
+                  changed_trace_ids = trs.each_key.reject { |trace_id| trs[trace_id] == @persisted_trace_rows[trace_id] }
+                  trace_changes = { dirty: @traces_dirty || changed_trace_ids.any?, changed_ids: changed_trace_ids }
+                  [ts, as, trs, trace_changes, @associations_dirty]
                 end
-                return nil unless traces_dirty || associations_dirty
+                return nil unless trace_changes[:dirty] || associations_dirty
 
-                [traces_snapshot, associations_snapshot, trace_rows_snapshot, traces_dirty, associations_dirty]
+                [traces_snapshot, associations_snapshot, trace_rows_snapshot, trace_changes, associations_dirty]
               end
 
-              def persist_dirty_traces(db, trace_rows_snapshot, scoped_trace_ids, memory_trace_ids, traces_dirty)
-                return [] unless traces_dirty
+              def persist_dirty_traces(db, trace_rows_snapshot, trace_changes, stale_ids)
+                return unless trace_changes[:dirty] || !stale_ids.empty?
 
                 ds = db[:memory_traces]
-                trace_rows_snapshot.each_value do |row|
-                  ds.insert_conflict(:replace).insert(row)
+                trace_changes[:changed_ids].each do |trace_id|
+                  ds.insert_conflict(:replace).insert(trace_rows_snapshot.fetch(trace_id))
                 end
-                stale_ids = scoped_trace_ids - memory_trace_ids
                 db[:memory_traces].where(trace_id: stale_ids).delete unless stale_ids.empty?
-                stale_ids
               end
 
               def persist_dirty_associations(db, associations_snapshot, scoped_trace_ids, memory_trace_ids, stale_ids, dirty)
                 assoc_scope_ids = (scoped_trace_ids + memory_trace_ids).uniq
                 return unless (dirty || !stale_ids.empty?) && !assoc_scope_ids.empty?
 
-                db[:memory_associations].where(trace_id_a: assoc_scope_ids).delete
-                db[:memory_associations].where(trace_id_b: assoc_scope_ids).delete
+                association_columns = db[:memory_associations].columns
+                partitioned_associations = association_columns.include?(:partition_id)
+                if partitioned_associations
+                  db[:memory_associations].where(partition_id: @partition_id).delete
+                else
+                  assoc_scope_ids.each_slice(ASSOCIATION_LOAD_BATCH_SIZE) do |ids|
+                    db[:memory_associations].where(trace_id_a: ids).delete
+                    db[:memory_associations].where(trace_id_b: ids).delete
+                  end
+                end
+
                 associations_snapshot.each do |id_a, targets|
                   targets.each do |id_b, count|
-                    db[:memory_associations].insert(trace_id_a: id_a, trace_id_b: id_b, coactivation_count: count)
+                    row = { trace_id_a: id_a, trace_id_b: id_b, coactivation_count: count }
+                    row[:partition_id] = @partition_id if partitioned_associations
+                    db[:memory_associations].insert(row)
                   end
                 end
               end
@@ -231,13 +245,7 @@ module Legion
                   @traces[row[:trace_id]] = deserialize_trace_from_db(row)
                 end
 
-                trace_ids = @traces.keys
-                unless trace_ids.empty?
-                  db[:memory_associations].where(trace_id_a: trace_ids).each do |row|
-                    @associations[row[:trace_id_a]] ||= {}
-                    @associations[row[:trace_id_a]][row[:trace_id_b]] = row[:coactivation_count]
-                  end
-                end
+                load_local_associations(db)
 
                 @persisted_trace_rows = @traces.transform_values { |trace| serialize_trace_for_db(trace) }
                 @traces_dirty = false
@@ -245,6 +253,24 @@ module Legion
               end
 
               private
+
+              def load_local_associations(db)
+                association_columns = db[:memory_associations].columns
+                if association_columns.include?(:partition_id)
+                  db[:memory_associations].where(partition_id: @partition_id).each { |row| load_association_row(row) }
+                else
+                  @traces.keys.each_slice(ASSOCIATION_LOAD_BATCH_SIZE) do |trace_ids|
+                    db[:memory_associations].where(trace_id_a: trace_ids).each { |row| load_association_row(row) }
+                  end
+                end
+              end
+
+              def load_association_row(row)
+                return unless @traces.key?(row[:trace_id_a])
+
+                @associations[row[:trace_id_a]] ||= {}
+                @associations[row[:trace_id_a]][row[:trace_id_b]] = row[:coactivation_count]
+              end
 
               def resolve_partition_id
                 Legion::Settings.dig(:agent, :id) || 'default'

--- a/lib/legion/extensions/agentic/memory/trace/local_migrations/20260427000001_add_partition_id_to_memory_associations.rb
+++ b/lib/legion/extensions/agentic/memory/trace/local_migrations/20260427000001_add_partition_id_to_memory_associations.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:memory_associations) do
+      add_column :partition_id, String
+      add_index :partition_id
+    end
+
+    run <<~SQL
+      UPDATE memory_associations
+      SET partition_id = (
+        SELECT memory_traces.partition_id
+        FROM memory_traces
+        WHERE memory_traces.trace_id = memory_associations.trace_id_a
+      )
+      WHERE partition_id IS NULL
+    SQL
+  end
+
+  down do
+    alter_table(:memory_associations) do
+      drop_index :partition_id
+      drop_column :partition_id
+    end
+  end
+end

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.30'
+        VERSION = '0.1.31'
       end
     end
   end

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.29'
+        VERSION = '0.1.30'
       end
     end
   end

--- a/spec/legion/extensions/agentic/memory/consolidation/helpers/extractor_spec.rb
+++ b/spec/legion/extensions/agentic/memory/consolidation/helpers/extractor_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Legion::Extensions::Agentic::Memory::Consolidation::Helpers::Extractor do
+  it 'extracts heuristic categories from chat-like messages' do
+    summary = described_class.extract([
+                                        { content: 'We went with SQLite because it is local.' },
+                                        { content: 'Never send embeddings to vLLM.' },
+                                        { content: 'The failing query was fixed after adding partition_id.' },
+                                        { content: 'Found the association load root cause.' }
+                                      ])
+
+    expect(summary[:decisions]).to include('We went with SQLite because it is local.')
+    expect(summary[:preferences]).to include('Never send embeddings to vLLM.')
+    expect(summary[:milestones]).to include('The failing query was fixed after adding partition_id.')
+    expect(summary[:problems]).to include('The failing query was fixed after adding partition_id.')
+    expect(summary[:discoveries]).to include('Found the association load root cause.')
+  end
+end

--- a/spec/legion/extensions/agentic/memory/consolidation/pre_compact_spec.rb
+++ b/spec/legion/extensions/agentic/memory/consolidation/pre_compact_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Legion::Extensions::Agentic::Memory::Consolidation::PreCompact do
+  let(:store) do
+    Class.new do
+      attr_reader :traces, :flushed
+
+      def initialize
+        @traces = []
+        @flushed = false
+      end
+
+      def store(trace)
+        @traces << trace
+      end
+
+      def flush
+        @flushed = true
+      end
+    end.new
+  end
+
+  let(:session) do
+    [
+      { role: :user, content: 'We decided to use local memory because vLLM was failing.' },
+      { role: :assistant, content: 'I found the root cause and fixed the startup crash.' },
+      { role: :user, content: 'Always keep embeddings local.' }
+    ]
+  end
+
+  it 'extracts high-signal compaction details and stores them as traces' do
+    result = described_class.before_compact(session: session, agent_id: 'agent-1', store: store)
+
+    expect(result[:success]).to be true
+    expect(result[:saved]).to be >= 3
+    expect(store.flushed).to be true
+    expect(store.traces.map { |trace| trace[:partition_id] }.uniq).to eq(['agent-1'])
+    expect(store.traces.flat_map { |trace| trace[:domain_tags] }).to include('pre_compact', 'decisions', 'preferences', 'problems')
+  end
+
+  it 'promotes extracted entries to Apollo when an ingest writer is provided' do
+    apollo = class_double('Apollo', ingest: true)
+
+    described_class.before_compact(session: session, agent_id: 'agent-1', store: store, apollo: apollo)
+
+    expect(apollo).to have_received(:ingest).at_least(:once)
+  end
+end

--- a/spec/legion/extensions/agentic/memory/trace/helpers/cache_store_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/cache_store_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::CacheStore do
+  describe '#initialize' do
+    it 'has logging and cache helpers when loaded directly' do
+      allow(Legion::Cache).to receive(:get).and_return(nil)
+
+      store = described_class.new
+
+      expect(store).to respond_to(:log)
+      expect(store).to respond_to(:cache_get)
+    end
+  end
+
+  describe '#flush' do
+    it 'passes cache TTL as a keyword argument' do
+      allow(Legion::Cache).to receive(:get).and_return(nil)
+      allow(Legion::Cache).to receive(:set).and_return(true)
+      store = described_class.new
+      trace = Legion::Extensions::Agentic::Memory::Trace::Helpers::Trace.new_trace(
+        type:            :semantic,
+        content_payload: { fact: 'cache flush' }
+      )
+
+      store.store(trace)
+      store.flush
+
+      expect(Legion::Cache).to have_received(:set).with(
+        a_string_including(trace[:trace_id]),
+        trace,
+        ttl:   described_class::TTL,
+        async: false,
+        phi:   false
+      )
+    end
+  end
+end

--- a/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
@@ -131,6 +131,31 @@ RSpec.describe 'lex-memory local SQLite persistence' do
       expect(db[:memory_traces].count).to eq(1)
     end
 
+    it 'persists only the changed trace row on subsequent saves' do
+      traces = Array.new(3) do |index|
+        trace_helper.new_trace(
+          type:            :semantic,
+          content_payload: { fact: "trace #{index}" },
+          domain_tags:     ['storage']
+        )
+      end
+      traces.each { |trace| store.store(trace) }
+      store.save_to_local
+
+      io = StringIO.new
+      logger = Logger.new(io)
+      logger.level = Logger::DEBUG
+      Legion::Data::Local.connection.loggers << logger
+
+      store.traces[traces.first[:trace_id]][:strength] = 0.42
+      store.save_to_local
+
+      trace_writes = io.string.scan(/INSERT(?: OR REPLACE)? INTO [`"]memory_traces[`"]/)
+      expect(trace_writes.size).to eq(1)
+    ensure
+      Legion::Data::Local.connection.loggers.delete(logger) if logger
+    end
+
     it 'removes pruned traces from the database' do
       store.store(semantic_trace)
       store.store(episodic_trace)
@@ -320,6 +345,29 @@ RSpec.describe 'lex-memory local SQLite persistence' do
       fresh = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
       count = fresh.associations[semantic_trace[:trace_id]][episodic_trace[:trace_id]]
       expect(count).to eq(threshold)
+    end
+
+    it 'loads associations by partition instead of one trace-id IN list' do
+      store.store(semantic_trace)
+      store.store(episodic_trace)
+
+      threshold = Legion::Extensions::Agentic::Memory::Trace::Helpers::Trace::COACTIVATION_THRESHOLD
+      threshold.times { store.record_coactivation(semantic_trace[:trace_id], episodic_trace[:trace_id]) }
+      store.save_to_local
+
+      io = StringIO.new
+      logger = Logger.new(io)
+      logger.level = Logger::DEBUG
+      Legion::Data::Local.connection.loggers << logger
+
+      fresh = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
+
+      expect(fresh.associations[semantic_trace[:trace_id]][episodic_trace[:trace_id]]).to eq(threshold)
+      expect(io.string).to include('memory_associations')
+      expect(io.string).to include('partition_id')
+      expect(io.string).not_to match(/trace_id_a[`"]? IN/i)
+    ensure
+      Legion::Data::Local.connection.loggers.delete(logger) if logger
     end
   end
 end


### PR DESCRIPTION
## Summary
- Persists only changed memory traces instead of rewriting the full partition.
- Adds partition_id to local memory associations and restores associations by partition, avoiding the giant trace-id IN-list association load.
- Keeps chunked fallback behavior for older schemas.
- Fixes CacheStore direct-load helper wiring and cache TTL keyword calls.
- Adds a heuristic pre-compaction emergency memory save path and synchronous pre-compaction event listeners.

## Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A
- bundle exec rubocop

Fixes #21
Fixes #22
Fixes #27
Fixes #31
