### PR TITLE
Fix agentic gap analysis findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.32] - 2026-05-07
+### Fixed
+- Trace association retrieval now snapshots associated traces under the store mutex before filtering.
+- Local trace restore preserves symbol keys for JSON fields that are consumed as symbol-keyed hashes.
+
 ## [0.1.31] - 2026-04-27
 ### Added
 - Add a heuristic pre-compaction memory save path and synchronous pre-compaction event listeners for `chat.pre_compact`, `context.pre_compact`, and `conversation.pre_compact`.

--- a/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
@@ -70,11 +70,14 @@ module Legion
               end
 
               def retrieve_associated(trace_id, min_strength: 0.0, limit: 20)
-                trace = @traces[trace_id]
-                return [] unless trace
+                associated = @mutex.synchronize do
+                  trace = @traces[trace_id]
+                  next [] unless trace
 
-                trace[:associated_traces]
-                  .filter_map { |id| @traces[id] }
+                  trace[:associated_traces].filter_map { |id| @traces[id]&.dup }
+                end
+
+                associated
                   .select { |t| t[:strength] >= min_strength }
                   .sort_by { |t| -t[:strength] }
                   .first(limit)
@@ -354,11 +357,25 @@ module Legion
                 raw
               end
 
-              def parse_db_json(raw, field, **_opts, &default)
-                Legion::JSON.load(raw.to_s)
+              def parse_db_json(raw, field, symbolize: false, &default)
+                parsed = Legion::JSON.load(raw.to_s)
+                symbolize ? symbolize_keys(parsed) : parsed
               rescue StandardError => e
                 log.error "[trace_persistence] deserialize_trace_from_db #{field}: #{e.message}"
                 default&.call
+              end
+
+              def symbolize_keys(value)
+                case value
+                when Hash
+                  value.each_with_object({}) do |(key, nested), memo|
+                    memo[key.to_sym] = symbolize_keys(nested)
+                  end
+                when Array
+                  value.map { |nested| symbolize_keys(nested) }
+                else
+                  value
+                end
               end
 
               def link_traces(id_a, id_b)

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.31'
+        VERSION = '0.1.32'
       end
     end
   end

--- a/spec/legion/extensions/agentic/memory/trace/helpers/store_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/store_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::Store do
       associated = store.retrieve_associated(semantic_trace[:trace_id])
       expect(associated.size).to eq(0)
     end
+
+    it 'snapshots associated traces while holding the store mutex' do
+      store.store(semantic_trace)
+      store.store(episodic_trace)
+      semantic_trace[:associated_traces] << episodic_trace[:trace_id]
+
+      mutex = store.instance_variable_get(:@mutex)
+      expect(mutex).to receive(:synchronize).and_call_original
+
+      associated = store.retrieve_associated(semantic_trace[:trace_id])
+      expect(associated.map { |trace| trace[:trace_id] }).to eq([episodic_trace[:trace_id]])
+    end
   end
 
   describe '#all_traces' do

--- a/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
@@ -249,6 +249,23 @@ RSpec.describe 'lex-memory local SQLite persistence' do
       expect(fresh.get(episodic_trace[:trace_id])).not_to be_nil
     end
 
+    it 'honors symbolize parsing for JSON hash fields' do
+      trace = trace_helper.new_trace(
+        type:              :semantic,
+        content_payload:   { fact: 'symbolized' },
+        domain_tags:       ['json'],
+        emotional_valence: { joy: 0.8 }
+      )
+      store.store(trace)
+      store.save_to_local
+
+      fresh = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
+      restored = fresh.get(trace[:trace_id])
+
+      expect(restored[:emotional_valence]).to include(joy: 0.8)
+      expect(restored[:emotional_valence]).not_to have_key('joy')
+    end
+
     it 'restores associations from the database into a fresh store' do
       store.store(semantic_trace)
       store.store(episodic_trace)


### PR DESCRIPTION
## Summary
- Fixes the 2026-05-06 extensions-agentic gap-analysis findings scoped to this repo.
- Adds focused regression coverage for the corrected failure mode.
- Updates version and changelog metadata.

## Verification
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A