### PR TITLE
Fix idle memory trace churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 .rspec_status
 *.gem
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.34] - 2026-05-08
+### Fixed
+- Deferred GAIA heartbeat maintenance no longer initializes the shared trace store just to return a deferred summary, avoiding idle local trace table scans.
+- `Store#parse_db_content` now returns bracket-prefixed raw trace/log text without JSON parse attempts or malformed JSON debug noise while still parsing real JSON objects and arrays.
+
 ## [0.1.33] - 2026-05-07
 ### Fixed
 - `PostgresStore#parse_json_or_raw` no longer attempts JSON parse on plain-text content — checks for `{`/`[` prefix before parsing, eliminating ERROR log spam during bulk reads with mixed content types

--- a/lib/legion/extensions/agentic/memory/trace/client.rb
+++ b/lib/legion/extensions/agentic/memory/trace/client.rb
@@ -18,12 +18,14 @@ module Legion
             attr_reader :store
 
             def initialize(store: nil, **)
-              @default_store = store || Legion::Extensions::Agentic::Memory::Trace.shared_store
+              @default_store = store if store
             end
 
             private
 
-            attr_reader :default_store
+            def default_store
+              @default_store ||= Legion::Extensions::Agentic::Memory::Trace.shared_store
+            end
           end
         end
       end

--- a/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
@@ -348,13 +348,20 @@ module Legion
                 return raw unless raw.is_a?(String)
 
                 stripped = raw.strip
-                return raw unless stripped.start_with?('{', '[')
+                return raw unless parseable_content_json?(stripped)
 
                 parsed = Legion::JSON.load(stripped)
                 parsed.is_a?(Hash) || parsed.is_a?(Array) ? parsed : raw
-              rescue StandardError => e
-                log.debug "[trace_persistence] malformed JSON in content column, returning raw: #{e.message}"
+              rescue StandardError => _e
                 raw
+              end
+
+              def parseable_content_json?(value)
+                return true if value.start_with?('{')
+                return false unless value.start_with?('[')
+
+                first_array_value = value[1..]&.lstrip&.[](0)
+                %w[{ [ " ]].include?(first_array_value)
               end
 
               def parse_db_json(raw, field, symbolize: false, &default)

--- a/lib/legion/extensions/agentic/memory/trace/runners/consolidation.rb
+++ b/lib/legion/extensions/agentic/memory/trace/runners/consolidation.rb
@@ -31,12 +31,12 @@ module Legion
               end
 
               def decay_cycle(store: nil, tick_count: 1, maintenance: true, **)
-                store ||= default_store
                 unless maintenance
-                  deferred = deferred_decay_summary(store)
+                  deferred = deferred_decay_summary(store || cached_default_store)
                   return { **deferred }
                 end
 
+                store ||= default_store
                 decayed = 0
                 pruned = 0
                 total = trace_count(store)
@@ -139,7 +139,7 @@ module Legion
 
               def deferred_decay_summary(store)
                 summary = Legion::Extensions::Agentic::Memory::Trace.last_maintenance_summary || {}
-                current_count = trace_count(store)
+                current_count = store ? trace_count(store) : 0
 
                 {
                   decayed:       summary[:decayed] || 0,
@@ -171,6 +171,10 @@ module Legion
 
               def default_store
                 @default_store ||= Legion::Extensions::Agentic::Memory::Trace.shared_store
+              end
+
+              def cached_default_store
+                @default_store if instance_variable_defined?(:@default_store)
               end
 
               include Legion::Extensions::Helpers::Lex if defined?(Legion::Extensions::Helpers::Lex)

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.33'
+        VERSION = '0.1.34'
       end
     end
   end

--- a/spec/legion/extensions/agentic/memory/trace/client_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/client_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Client do
     expect(client).to respond_to(:erase_by_agent)
   end
 
+  it 'does not initialize the shared trace store until a store-backed operation needs it' do
+    allow(Legion::Extensions::Agentic::Memory::Trace).to receive(:shared_store)
+
+    described_class.new
+
+    expect(Legion::Extensions::Agentic::Memory::Trace).not_to have_received(:shared_store)
+  end
+
   it 'uses provided store' do
     store = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
     client = described_class.new(store: store)

--- a/spec/legion/extensions/agentic/memory/trace/helpers/store_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/store_spec.rb
@@ -128,6 +128,30 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::Store do
     end
   end
 
+  describe '#parse_db_content' do
+    let(:parser) { described_class.allocate }
+
+    it 'returns bracket-prefixed raw log text without logging malformed JSON noise' do
+      expect(parser).not_to receive(:log)
+
+      result = parser.send(:parse_db_content, '[tool][file_read] opened file')
+
+      expect(result).to eq('[tool][file_read] opened file')
+    end
+
+    it 'still parses JSON object content' do
+      result = parser.send(:parse_db_content, '{"event":"meeting"}')
+
+      expect(result).to eq({ event: 'meeting' })
+    end
+
+    it 'still parses JSON array content when it looks like serialized payload data' do
+      result = parser.send(:parse_db_content, '[{"event":"meeting"}]')
+
+      expect(result).to eq([{ event: 'meeting' }])
+    end
+  end
+
   describe '#count' do
     it 'returns number of stored traces' do
       expect(store.count).to eq(0)

--- a/spec/legion/extensions/agentic/memory/trace/runners/consolidation_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/runners/consolidation_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Runners::Consolidatio
   end
 
   describe '#decay_cycle' do
+    it 'does not initialize the shared store when Gaia defers heartbeat maintenance' do
+      runner = Object.new.extend(described_class)
+      allow(Legion::Extensions::Agentic::Memory::Trace).to receive(:shared_store)
+
+      result = runner.decay_cycle(maintenance: false)
+
+      expect(Legion::Extensions::Agentic::Memory::Trace).not_to have_received(:shared_store)
+      expect(result).to include(
+        decayed:   0,
+        pruned:    0,
+        total:     0,
+        remaining: 0,
+        deferred:  true,
+        reason:    :background_decay_actor
+      )
+    end
+
     it 'defers Gaia heartbeat decay work to the background actor when maintenance is false' do
       client.store_trace(type: :semantic, content_payload: {})
 


### PR DESCRIPTION
Summary
- Avoid shared trace store initialization during deferred GAIA heartbeat maintenance.
- Keep raw bracket-prefixed trace content from JSON parsing/log spam.
- Add regression specs plus release metadata.

Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A