### PR TITLE
Normalize trace affect persistence across stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Deferred GAIA heartbeat maintenance no longer initializes the shared trace store just to return a deferred summary, avoiding idle local trace table scans.
 - `Store#parse_db_content` now returns bracket-prefixed raw trace/log text without JSON parse attempts or malformed JSON debug noise while still parsing real JSON objects and arrays.
 
+## [0.1.35] - 2026-05-15
+### Fixed
+- Normalize trace affect fields before persisting through in-memory, cache, local SQLite, and Postgres stores so string-backed values do not crash or silently collapse to `0.0`.
+- Preserve numeric `emotional_valence` across local trace persistence and normalize legacy structured payloads when they are reloaded.
+
 ## [0.1.33] - 2026-05-07
 ### Fixed
 - `PostgresStore#parse_json_or_raw` no longer attempts JSON parse on plain-text content — checks for `{`/`[` prefix before parsing, eliminating ERROR log spam during bulk reads with mixed content types

--- a/lib/legion/extensions/agentic/memory/archaeology/helpers/archaeology_engine.rb
+++ b/lib/legion/extensions/agentic/memory/archaeology/helpers/archaeology_engine.rb
@@ -164,9 +164,9 @@ module Legion
                 site.survey.merge(
                   depth_progress: depth_progress(site),
                   artifact_types: site.artifacts_found
-                                  .each_with_object(Hash.new(0)) do |a, h|
-                                    h[a.artifact_type] += 1
-                                  end
+                                      .each_with_object(Hash.new(0)) do |a, h|
+                                        h[a.artifact_type] += 1
+                                      end
                 )
               end
 

--- a/lib/legion/extensions/agentic/memory/trace/helpers/cache_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/cache_store.rb
@@ -38,11 +38,12 @@ module Legion
               end
 
               def store(trace)
+                normalized_trace = Helpers::Trace.normalize_trace_affect(trace)
                 @mutex.synchronize do
-                  @traces[trace[:trace_id]] = trace
-                  @dirty_ids << trace[:trace_id]
+                  @traces[normalized_trace[:trace_id]] = normalized_trace
+                  @dirty_ids << normalized_trace[:trace_id]
                 end
-                trace[:trace_id]
+                normalized_trace[:trace_id]
               end
 
               def get(trace_id)

--- a/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
@@ -27,15 +27,16 @@ module Legion
               def store(trace)
                 return nil unless db_ready?
 
-                row = serialize_trace(trace)
+                normalized_trace = Helpers::Trace.normalize_trace_affect(trace)
+                row = serialize_trace(normalized_trace)
                 ds  = db[TRACES_TABLE]
                 if db.adapter_scheme == :mysql2
                   ds.insert_conflict(update: row.except(:trace_id)).insert(row)
                 else
                   ds.insert_conflict(target: :trace_id, update: row.except(:trace_id)).insert(row)
                 end
-                HotTier.cache_trace(trace, tenant_id: @tenant_id, agent_id: @agent_id) if HotTier.available?
-                trace[:trace_id]
+                HotTier.cache_trace(normalized_trace, tenant_id: @tenant_id, agent_id: @agent_id) if HotTier.available?
+                normalized_trace[:trace_id]
               rescue StandardError => e
                 log_warn("store failed: #{e.message}")
                 nil
@@ -299,7 +300,7 @@ module Legion
                 tags    = trace[:domain_tags]
                 assocs  = trace[:associated_traces]
                 conf    = trace[:confidence]
-                ev      = trace[:emotional_valence]
+                ev      = Helpers::Trace.normalize_emotional_valence(trace[:emotional_valence])
 
                 {
                   trace_id:                trace[:trace_id],
@@ -314,8 +315,8 @@ module Legion
                   strength:                trace[:strength],
                   peak_strength:           trace[:peak_strength],
                   base_decay_rate:         trace[:base_decay_rate],
-                  emotional_valence:       ev.is_a?(Numeric) ? ev.to_f : 0.0,
-                  emotional_intensity:     trace[:emotional_intensity],
+                  emotional_valence:       ev,
+                  emotional_intensity:     Helpers::Trace.normalize_emotional_intensity(trace[:emotional_intensity]),
                   origin:                  sanitize_pg_string(trace[:origin].to_s),
                   source_agent_id:         sanitize_pg_string(trace[:source_agent_id]),
                   storage_tier:            sanitize_pg_string(trace[:storage_tier].to_s),

--- a/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/store.rb
@@ -29,7 +29,7 @@ module Legion
               end
 
               def store(trace)
-                persisted_trace = trace.dup
+                persisted_trace = Helpers::Trace.normalize_trace_affect(trace)
                 persisted_trace[:partition_id] ||= @partition_id
                 @mutex.synchronize do
                   @traces_dirty = true if @traces[persisted_trace[:trace_id]] != persisted_trace
@@ -120,7 +120,7 @@ module Legion
                 snapshot = Array(traces).each_with_object({}) do |trace, memo|
                   next unless trace.is_a?(Hash) && trace[:trace_id]
 
-                  restored = trace.dup
+                  restored = Helpers::Trace.normalize_trace_affect(trace)
                   restored[:partition_id] ||= @partition_id
                   memo[restored[:trace_id]] = restored
                 end
@@ -294,7 +294,7 @@ module Legion
                   strength:                trace[:strength],
                   peak_strength:           trace[:peak_strength],
                   base_decay_rate:         trace[:base_decay_rate],
-                  emotional_valence:       trace[:emotional_valence].is_a?(Hash) ? ::JSON.generate(trace[:emotional_valence]) : nil,
+                  emotional_valence:       Helpers::Trace.normalize_emotional_valence(trace[:emotional_valence]).to_s,
                   emotional_intensity:     trace[:emotional_intensity],
                   domain_tags:             trace[:domain_tags].is_a?(Array) ? ::JSON.generate(trace[:domain_tags]) : nil,
                   origin:                  trace[:origin].to_s,
@@ -325,7 +325,7 @@ module Legion
                   strength:                row[:strength],
                   peak_strength:           row[:peak_strength],
                   base_decay_rate:         row[:base_decay_rate],
-                  emotional_valence:       parse_db_json(row[:emotional_valence], 'emotional_valence', symbolize: true) { 0.0 },
+                  emotional_valence:       deserialize_emotional_valence(row[:emotional_valence]),
                   emotional_intensity:     row[:emotional_intensity],
                   domain_tags:             parse_db_json(row[:domain_tags], 'domain_tags') { [] },
                   origin:                  row[:origin]&.to_sym,
@@ -362,6 +362,12 @@ module Legion
 
                 first_array_value = value[1..]&.lstrip&.[](0)
                 %w[{ [ " ]].include?(first_array_value)
+              end
+
+              def deserialize_emotional_valence(raw)
+                return 0.0 if raw.nil? || raw.to_s.strip.empty?
+
+                Helpers::Trace.normalize_emotional_valence(raw)
               end
 
               def parse_db_json(raw, field, symbolize: false, &default)

--- a/lib/legion/extensions/agentic/memory/trace/helpers/trace.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/trace.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'securerandom'
 
 module Legion
@@ -48,6 +49,7 @@ module Legion
               ASSOCIATION_BONUS       = 0.15  # bonus for Hebbian-associated traces
               MAX_ASSOCIATIONS        = 20    # max Hebbian links per trace
               COACTIVATION_THRESHOLD  = 3     # co-activations before Hebbian link forms
+              VALENCE_SCALAR_KEYS     = %i[valence emotional_valence sentiment polarity score].freeze
 
               module_function
 
@@ -59,6 +61,10 @@ module Legion
                 raise ArgumentError, "invalid origin: #{origin}" unless ORIGINS.include?(origin)
 
                 now = Time.now.utc
+                emotional_context = normalize_trace_affect(
+                  emotional_valence:   emotional_valence,
+                  emotional_intensity: emotional_intensity
+                )
 
                 {
                   trace_id:                SecureRandom.uuid,
@@ -68,8 +74,8 @@ module Legion
                   strength:                STARTING_STRENGTHS[type],
                   peak_strength:           STARTING_STRENGTHS[type],
                   base_decay_rate:         BASE_DECAY_RATES[type],
-                  emotional_valence:       emotional_valence.clamp(-1.0, 1.0),
-                  emotional_intensity:     emotional_intensity.clamp(0.0, 1.0),
+                  emotional_valence:       emotional_context[:emotional_valence],
+                  emotional_intensity:     emotional_context[:emotional_intensity],
                   domain_tags:             Array(domain_tags),
                   origin:                  origin,
                   source_agent_id:         source_agent_id,
@@ -98,10 +104,88 @@ module Legion
                 true
               end
 
+              def normalize_trace_affect(trace)
+                normalized = trace.dup
+                normalized[:emotional_valence] = normalize_emotional_valence(normalized[:emotional_valence])
+                normalized[:emotional_intensity] = normalize_emotional_intensity(normalized[:emotional_intensity])
+                normalized
+              end
+
+              def normalize_emotional_valence(value)
+                normalize_scalar(value, min: -1.0, max: 1.0, hash_keys: VALENCE_SCALAR_KEYS)
+              end
+
+              def normalize_emotional_intensity(value)
+                normalize_scalar(value, min: 0.0, max: 1.0)
+              end
+
               def default_partition_id
                 Legion::Settings.dig(:agent, :id) || 'default'
               rescue StandardError => _e
                 'default'
+              end
+
+              def normalize_scalar(value, min:, max:, hash_keys: [])
+                case value
+                when Numeric
+                  value.to_f.clamp(min, max)
+                when String
+                  normalize_string_scalar(value, min: min, max: max, hash_keys: hash_keys)
+                when Hash
+                  normalize_hash_scalar(value, min: min, max: max, hash_keys: hash_keys)
+                else
+                  0.0
+                end
+              end
+
+              def normalize_string_scalar(value, min:, max:, hash_keys:)
+                stripped = value.strip
+                return 0.0 if stripped.empty?
+
+                Float(stripped).clamp(min, max)
+              rescue ArgumentError, TypeError => e
+                Legion::Logging.debug("[memory][trace] normalize_string_scalar fallback: #{e.message}")
+                parsed = parse_structured_scalar(stripped)
+                return normalize_scalar(parsed, min: min, max: max, hash_keys: hash_keys) if parsed
+
+                0.0
+              end
+
+              def normalize_hash_scalar(value, min:, max:, hash_keys:)
+                symbolized = symbolize_keys(value)
+                scalar_value = hash_keys.lazy.map { |key| symbolized[key] }.find { |candidate| scalar_candidate?(candidate) }
+                return normalize_scalar(scalar_value, min: min, max: max, hash_keys: hash_keys) if scalar_candidate?(scalar_value)
+
+                numeric_values = symbolized.values.select { |candidate| scalar_candidate?(candidate) }
+                return normalize_scalar(numeric_values.first, min: min, max: max, hash_keys: hash_keys) if numeric_values.one?
+
+                0.0
+              end
+
+              def parse_structured_scalar(value)
+                return unless value.start_with?('{', '[')
+
+                ::JSON.parse(value)
+              rescue ::JSON::ParserError => e
+                Legion::Logging.debug("[memory][trace] parse_structured_scalar ignored: #{e.message}")
+                nil
+              end
+
+              def scalar_candidate?(value)
+                value.is_a?(Numeric) || value.is_a?(String)
+              end
+
+              def symbolize_keys(value)
+                case value
+                when Hash
+                  value.each_with_object({}) do |(key, nested), memo|
+                    memo[key.to_sym] = symbolize_keys(nested)
+                  end
+                when Array
+                  value.map { |nested| symbolize_keys(nested) }
+                else
+                  value
+                end
               end
             end
           end

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.34'
+        VERSION = '0.1.35'
       end
     end
   end

--- a/spec/legion/extensions/agentic/memory/trace/helpers/postgres_store_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/postgres_store_spec.rb
@@ -238,6 +238,20 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::PostgresStor
     end
   end
 
+  describe 'emotional valence normalization' do
+    it 'normalizes string-backed affect fields before persisting' do
+      trace = trace_helper.new_trace(type: :episodic, content_payload: { event: 'partner ping' })
+      trace[:emotional_valence] = '0.7'
+      trace[:emotional_intensity] = '0.9'
+
+      store.store(trace)
+
+      row = db[:memory_traces].where(trace_id: trace[:trace_id]).first
+      expect(row[:emotional_valence]).to be_within(0.001).of(0.7)
+      expect(row[:emotional_intensity]).to be_within(0.001).of(0.9)
+    end
+  end
+
   # --- retrieve_by_type ---
 
   describe '#retrieve_by_type' do

--- a/spec/legion/extensions/agentic/memory/trace/helpers/trace_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/helpers/trace_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe Legion::Extensions::Agentic::Memory::Trace::Helpers::Trace do
       expect(trace[:emotional_intensity]).to eq(0.0)
     end
 
+    it 'normalizes string and structured emotional values safely' do
+      trace = described_class.new_trace(
+        type:                :episodic,
+        content_payload:     { event: 'partner ping' },
+        emotional_valence:   '{:urgency=>0.6, :importance=>0.8}',
+        emotional_intensity: '0.75'
+      )
+
+      expect(trace[:emotional_valence]).to eq(0.0)
+      expect(trace[:emotional_intensity]).to eq(0.75)
+    end
+
+    it 'extracts scalar valence from hash payloads when an explicit valence key exists' do
+      trace = described_class.new_trace(
+        type:                :semantic,
+        content_payload:     { fact: 'test' },
+        emotional_valence:   { valence: 0.4 },
+        emotional_intensity: '2.0'
+      )
+
+      expect(trace[:emotional_valence]).to eq(0.4)
+      expect(trace[:emotional_intensity]).to eq(1.0)
+    end
+
     it 'rejects invalid trace types' do
       expect do
         described_class.new_trace(type: :bogus, content_payload: {})

--- a/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
+++ b/spec/legion/extensions/agentic/memory/trace/local_persistence_spec.rb
@@ -249,12 +249,12 @@ RSpec.describe 'lex-memory local SQLite persistence' do
       expect(fresh.get(episodic_trace[:trace_id])).not_to be_nil
     end
 
-    it 'honors symbolize parsing for JSON hash fields' do
+    it 'restores numeric emotional_valence values from local persistence' do
       trace = trace_helper.new_trace(
         type:              :semantic,
         content_payload:   { fact: 'symbolized' },
         domain_tags:       ['json'],
-        emotional_valence: { joy: 0.8 }
+        emotional_valence: 0.8
       )
       store.store(trace)
       store.save_to_local
@@ -262,8 +262,25 @@ RSpec.describe 'lex-memory local SQLite persistence' do
       fresh = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
       restored = fresh.get(trace[:trace_id])
 
-      expect(restored[:emotional_valence]).to include(joy: 0.8)
-      expect(restored[:emotional_valence]).not_to have_key('joy')
+      expect(restored[:emotional_valence]).to be_within(0.001).of(0.8)
+    end
+
+    it 'normalizes legacy JSON emotional_valence payloads on load' do
+      trace = trace_helper.new_trace(
+        type:            :semantic,
+        content_payload: { fact: 'legacy' },
+        domain_tags:     ['json']
+      )
+      store.store(trace)
+      store.save_to_local
+
+      db = Legion::Data::Local.connection
+      db[:memory_traces].where(trace_id: trace[:trace_id]).update(emotional_valence: '{"valence":0.8}')
+
+      fresh = Legion::Extensions::Agentic::Memory::Trace::Helpers::Store.new
+      restored = fresh.get(trace[:trace_id])
+
+      expect(restored[:emotional_valence]).to be_within(0.001).of(0.8)
     end
 
     it 'restores associations from the database into a fresh store' do


### PR DESCRIPTION
## Summary
- normalize trace affect fields in the trace helper before they hit any storage backend
- keep in-memory, cache, SQLite, and Postgres trace stores aligned on numeric affect persistence
- add regression coverage for string-backed affect input and local/postgres persistence

## Verification
- bundle exec rubocop -A
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt