### PR TITLE
Fix parse_json_or_raw feedback loop causing 100k+ errors/day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.38] - 2026-05-27
+### Fixed
+- `PostgresStore#parse_json_or_raw` now requires matching start/end delimiters (`{}`/`[]`) before attempting JSON parse — eliminates 100k+/day error log spam from bracket-prefixed text content (e.g. `[trace_persistence] ...`) that triggered a self-amplifying feedback loop via RabbitMQ logging
+- `PostgresStore#parse_json_array` applies same delimiter guard
+- Removed error-level logging from JSON parse fallback path — non-parseable content is the expected "or_raw" code path, not an error condition
+
 ## [0.1.37] - 2026-05-17
 ### Added
 - `Memory::Diary` sub-module — per-agent chronological session diary with write, read, and search.

--- a/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
@@ -398,22 +398,24 @@ module Legion
                 return raw unless raw.is_a?(String)
 
                 stripped = raw.strip
-                return raw unless stripped.start_with?('{', '[')
+                return raw unless (stripped.start_with?('{') && stripped.end_with?('}')) ||
+                                  (stripped.start_with?('[') && stripped.end_with?(']'))
 
                 parsed = Legion::JSON.load(stripped)
                 parsed.is_a?(Hash) || parsed.is_a?(Array) ? parsed : raw
-              rescue StandardError => e
-                log.error "[trace_persistence] parse_json_or_raw: #{e.message}"
+              rescue StandardError
                 raw
               end
 
               def parse_json_array(raw)
                 return [] if raw.nil? || !raw.is_a?(String) || raw.strip.empty?
 
-                result = Legion::JSON.load(raw)
+                stripped = raw.strip
+                return [] unless stripped.start_with?('[') && stripped.end_with?(']')
+
+                result = Legion::JSON.load(stripped)
                 result.is_a?(Array) ? result : []
-              rescue StandardError => e
-                log.error "[trace_persistence] parse_json_array: #{e.message}"
+              rescue StandardError
                 []
               end
 

--- a/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
+++ b/lib/legion/extensions/agentic/memory/trace/helpers/postgres_store.rb
@@ -403,7 +403,8 @@ module Legion
 
                 parsed = Legion::JSON.load(stripped)
                 parsed.is_a?(Hash) || parsed.is_a?(Array) ? parsed : raw
-              rescue StandardError
+              rescue StandardError => e
+                log.debug "[trace_persistence] parse_json_or_raw: #{e.message}"
                 raw
               end
 
@@ -415,7 +416,8 @@ module Legion
 
                 result = Legion::JSON.load(stripped)
                 result.is_a?(Array) ? result : []
-              rescue StandardError
+              rescue StandardError => e
+                log.debug "[trace_persistence] parse_json_array: #{e.message}"
                 []
               end
 

--- a/lib/legion/extensions/agentic/memory/version.rb
+++ b/lib/legion/extensions/agentic/memory/version.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Agentic
       module Memory
-        VERSION = '0.1.37'
+        VERSION = '0.1.38'
       end
     end
   end


### PR DESCRIPTION
## Summary
- `PostgresStore#parse_json_or_raw` only checked `start_with?('[')` before JSON parse — bracket-prefixed text like `[trace_persistence] ...` passed the guard, failed parse, logged at error level to RMQ, which stored the error as trace content creating an infinite self-amplifying loop (5.2k msg/s, 100k queued messages)
- Added matching `end_with?` check — valid JSON requires `{}`/`[]` delimiter pairs
- Removed `log.error` from parse fallback — non-parseable content is the expected "or_raw" path, not an error condition
- Same fix applied to `parse_json_array`

## Impact
- Eliminates ~100k+ error messages/day per node
- Breaks the self-amplifying RMQ feedback loop
- Zero consumer ack on the logging queue means these were piling up unbounded

## Test plan
- [x] Full rspec suite passes (2058 examples, 0 failures)
- [x] Verified bracket-prefixed strings like `[trace_persistence] parse_json_or...` no longer trigger JSON parse
- [x] Verified valid JSON `{"key":"val"}` and `["arr"]` still parse correctly